### PR TITLE
chore: Cancel previous CI runs if newer commits are pushed

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,11 +1,14 @@
 name: CI
 on: [push, pull_request]
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
+
 env:
   BLIND_INDEX_MASTER_KEY: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
   LOCKBOX_MASTER_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
+
 jobs:
   linters:
     runs-on: ubuntu-latest

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,5 +1,8 @@
 name: CI
 on: [push, pull_request]
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 env:
   BLIND_INDEX_MASTER_KEY: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
   LOCKBOX_MASTER_KEY: "0000000000000000000000000000000000000000000000000000000000000000"


### PR DESCRIPTION
This PR prevents the overuse of GitHub Actions compute time and ensures the availability of runners for Actions runs by cancelling old CI runs when newer commits in the branch/PR are pushed.